### PR TITLE
Adding a comment to help others avoid a mistake

### DIFF
--- a/complete/src/main/java/hello/WeatherConfiguration.java
+++ b/complete/src/main/java/hello/WeatherConfiguration.java
@@ -11,6 +11,7 @@ public class WeatherConfiguration {
 	@Bean
 	public Jaxb2Marshaller marshaller() {
 		Jaxb2Marshaller marshaller = new Jaxb2Marshaller();
+		// this package must match the package in the <generatePackage> specified in pom.xml
 		marshaller.setContextPath("hello.wsdl");
 		return marshaller;
 	}


### PR DESCRIPTION
I think "hello.wsdl" sounds too much like a file name and not a package.  My colleague changed one and not the other and didn't see the problem.  I think this comment would help.