### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ This guide walks you through the process of consuming a link:/understanding/SOAP
 
 == What you'll build
 
-You will build a client that fetches country data data from a remote, WSDL-based web service using http://en.wikipedia.org/wiki/SOAP[SOAP].
+You will build a client that fetches country data data from a remote, WSDL-based web service using https://en.wikipedia.org/wiki/SOAP[SOAP].
 You can find out more about the country service, and run the service yourself by following https://spring.io/guides/gs/producing-web-service/[this guide].
 
 The service provides country data. You will be able to query data about a country based on its name.
@@ -42,7 +42,7 @@ Follow the steps in the https://spring.io/guides/gs/producing-web-service/[compa
 [[initial]]
 == Generate domain objects based on a WSDL
 
-The interface to a SOAP web service is captured in a http://en.wikipedia.org/wiki/Web_Services_Description_Language[WSDL]. JAXB provides an easy means to generate Java classes from a WSDL (or rather: the XSD contained in the `<Types/>` section of the WSDL).
+The interface to a SOAP web service is captured in a https://en.wikipedia.org/wiki/Web_Services_Description_Language[WSDL]. JAXB provides an easy means to generate Java classes from a WSDL (or rather: the XSD contained in the `<Types/>` section of the WSDL).
 The WSDL for the country service can be found at http://localhost:8080/ws/countries.wsdl.
 
 To generate Java classes from the WSDL in maven, you need the following plugin setup:
@@ -67,7 +67,7 @@ In both cases, the JAXB domain object generation process has been wired into the
 
 == Create a country service client
 
-To create a web service client, you simply have to extend the http://docs.spring.io/spring-ws/sites/2.0/apidocs/org/springframework/ws/client/core/support/WebServiceGatewaySupport.html[WebServiceGatewaySupport] class and code your operations:
+To create a web service client, you simply have to extend the https://docs.spring.io/spring-ws/sites/2.0/apidocs/org/springframework/ws/client/core/support/WebServiceGatewaySupport.html[WebServiceGatewaySupport] class and code your operations:
 
 `src/main/java/hello/CountryClient.java`
 [source,java]
@@ -79,8 +79,8 @@ The client contains one method: `getCountry` which does the actual SOAP exchange
 
 In this method, both the `GetCountryRequest` and the `GetCountryResponse` classes are derived from the WSDL and were generated in the JAXB generation process described in the previous step.
 It creates the `GetCountryRequest` request object and sets it up with the `country` parameter (the name of the country).
-After printing out the country name, it uses the http://docs.spring.io/spring-ws/sites/2.0/apidocs/org/springframework/ws/client/core/WebServiceTemplate.html[WebServiceTemplate] supplied by the `WebServiceGatewaySupport` base class to do the actual SOAP exchange.
-It passes the `GetCountryRequest` request object, as well as a `SoapActionCallback` to pass on a http://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383528[SOAPAction] header with the request, as the WSDL described that it needed this header in the `<soap:operation/>` elements.
+After printing out the country name, it uses the https://docs.spring.io/spring-ws/sites/2.0/apidocs/org/springframework/ws/client/core/WebServiceTemplate.html[WebServiceTemplate] supplied by the `WebServiceGatewaySupport` base class to do the actual SOAP exchange.
+It passes the `GetCountryRequest` request object, as well as a `SoapActionCallback` to pass on a https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383528[SOAPAction] header with the request, as the WSDL described that it needed this header in the `<soap:operation/>` elements.
 It casts the response into a `GetCountryResponse` object, which is then returned.
 
 == Configuring web service components
@@ -107,7 +107,7 @@ This application is packaged up to run from the console and retrieve the data fo
 include::complete/src/main/java/hello/Application.java[]
 ----
 
-The `main()` method defers to the http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html[`SpringApplication`] helper class, providing `CountryConfiguration.class` as an argument to its `run()` method. This tells Spring to read the annotation metadata from `CountryConfiguration` and to manage it as a component in the link:/understanding/application-context[Spring application context].
+The `main()` method defers to the https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html[`SpringApplication`] helper class, providing `CountryConfiguration.class` as an argument to its `run()` method. This tells Spring to read the annotation metadata from `CountryConfiguration` and to manage it as a component in the link:/understanding/application-context[Spring application context].
 
 NOTE: This application is hard coded to look up symbol 'MSFT' which correspond to Microsoft Corporation. Towards the end of this guide, you'll see how to plug in a different symbol without editing the code.
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.w3.org/TR/2000/NOTE-SOAP-20000508/ (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/2000/NOTE-SOAP-20000508/ ([https](https://www.w3.org/TR/2000/NOTE-SOAP-20000508/) result SSLException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/ ([https](https://docs.spring.io/spring-boot/docs/) result 200).
* [ ] http://en.wikipedia.org/wiki/SOAP with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/SOAP ([https](https://en.wikipedia.org/wiki/SOAP) result 200).
* [ ] http://en.wikipedia.org/wiki/Web_Services_Description_Language with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Web_Services_Description_Language ([https](https://en.wikipedia.org/wiki/Web_Services_Description_Language) result 200).
* [ ] http://docs.spring.io/spring-ws/sites/2.0/apidocs/org/springframework/ws/client/core/WebServiceTemplate.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-ws/sites/2.0/apidocs/org/springframework/ws/client/core/WebServiceTemplate.html ([https](https://docs.spring.io/spring-ws/sites/2.0/apidocs/org/springframework/ws/client/core/WebServiceTemplate.html) result 301).
* [ ] http://docs.spring.io/spring-ws/sites/2.0/apidocs/org/springframework/ws/client/core/support/WebServiceGatewaySupport.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-ws/sites/2.0/apidocs/org/springframework/ws/client/core/support/WebServiceGatewaySupport.html ([https](https://docs.spring.io/spring-ws/sites/2.0/apidocs/org/springframework/ws/client/core/support/WebServiceGatewaySupport.html) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/ws with 1 occurrences
* http://localhost:8080/ws/countries with 1 occurrences
* http://localhost:8080/ws/countries.wsdl with 2 occurrences
* http://spring.io/guides/gs-producing-web-service/GetCountryRequest with 1 occurrences